### PR TITLE
Add debug config

### DIFF
--- a/applications/ffd/ext/ffd_usb_audio_testing.cmake
+++ b/applications/ffd/ext/ffd_usb_audio_testing.cmake
@@ -1,8 +1,17 @@
-set(KEYWORD_USB_VENDOR_OUTPUT
+set(KEYWORD_USB_TESTING
     appconfUSB_ENABLED=1
     appconfUSB_AUDIO_ENABLED=1
     appconfUSB_AUDIO_MODE=appconfUSB_AUDIO_TESTING
     appconfMIC_SRC_DEFAULT=appconfMIC_SRC_USB
+    appconfUSB_ENABLED=1
+    appconfINFERENCE_USB_OUTPUT_ENABLED=1
+    appconfINFERENCE_RAW_OUTPUT=1
+)
+
+set(BYPASS_AUDIOPIPELINE_DEFINITIONS
+    appconfAUDIO_PIPELINE_SKIP_IC_AND_VAD=1
+    appconfAUDIO_PIPELINE_SKIP_NS=1
+    appconfAUDIO_PIPELINE_SKIP_AGC=1
 )
 
 #**********************
@@ -12,7 +21,7 @@ set(TARGET_NAME tile0_application_ffd_usb_audio_test)
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
 target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES} ${APP_EXT_SOURCES})
 target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES} ${APP_EXT_INCLUDES})
-target_compile_definitions(${TARGET_NAME} PUBLIC ${APP_COMPILE_DEFINITIONS} ${APP_EXT_COMPILE_DEFINITIONS} ${KEYWORD_USB_VENDOR_OUTPUT} THIS_XCORE_TILE=0)
+target_compile_definitions(${TARGET_NAME} PUBLIC ${APP_COMPILE_DEFINITIONS} ${APP_EXT_COMPILE_DEFINITIONS} ${KEYWORD_USB_TESTING} THIS_XCORE_TILE=0)
 target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS} ${APP_EXT_COMPILER_FLAGS})
 target_link_libraries(${TARGET_NAME} PUBLIC ${APP_COMMON_LINK_LIBRARIES} ${APP_EXT_COMMON_LINK_LIBRARIES} sln_avona::app::ffd::xk_voice_l71_ext)
 target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS})
@@ -22,7 +31,7 @@ set(TARGET_NAME tile1_application_ffd_usb_audio_test)
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
 target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES} ${APP_EXT_SOURCES})
 target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES} ${APP_EXT_INCLUDES})
-target_compile_definitions(${TARGET_NAME} PUBLIC ${APP_COMPILE_DEFINITIONS} ${APP_EXT_COMPILE_DEFINITIONS} ${KEYWORD_USB_VENDOR_OUTPUT} THIS_XCORE_TILE=1)
+target_compile_definitions(${TARGET_NAME} PUBLIC ${APP_COMPILE_DEFINITIONS} ${APP_EXT_COMPILE_DEFINITIONS} ${KEYWORD_USB_TESTING} THIS_XCORE_TILE=1)
 target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS} ${APP_EXT_COMPILER_FLAGS})
 target_link_libraries(${TARGET_NAME} PUBLIC ${APP_COMMON_LINK_LIBRARIES} ${APP_EXT_COMMON_LINK_LIBRARIES} sln_avona::app::ffd::xk_voice_l71_ext)
 target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS} )
@@ -32,7 +41,7 @@ set(TARGET_NAME tile0_application_ffd_usb_audio_test_dev)
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
 target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES} ${APP_EXT_SOURCES})
 target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES} ${APP_EXT_INCLUDES})
-target_compile_definitions(${TARGET_NAME} PUBLIC ${APP_COMPILE_DEFINITIONS} ${APP_EXT_COMPILE_DEFINITIONS} ${KEYWORD_USB_VENDOR_OUTPUT} THIS_XCORE_TILE=0)
+target_compile_definitions(${TARGET_NAME} PUBLIC ${APP_COMPILE_DEFINITIONS} ${APP_EXT_COMPILE_DEFINITIONS} ${KEYWORD_USB_TESTING} THIS_XCORE_TILE=0)
 target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS} ${APP_EXT_COMPILER_FLAGS})
 target_link_libraries(${TARGET_NAME} PUBLIC ${APP_COMMON_LINK_LIBRARIES} ${APP_EXT_COMMON_LINK_LIBRARIES} sln_avona::app::ffd::xcore_ai_explorer)
 target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS})
@@ -42,7 +51,47 @@ set(TARGET_NAME tile1_application_ffd_usb_audio_test_dev)
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
 target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES} ${APP_EXT_SOURCES})
 target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES} ${APP_EXT_INCLUDES})
-target_compile_definitions(${TARGET_NAME} PUBLIC ${APP_COMPILE_DEFINITIONS} ${APP_EXT_COMPILE_DEFINITIONS} ${KEYWORD_USB_VENDOR_OUTPUT} THIS_XCORE_TILE=1)
+target_compile_definitions(${TARGET_NAME} PUBLIC ${APP_COMPILE_DEFINITIONS} ${APP_EXT_COMPILE_DEFINITIONS} ${KEYWORD_USB_TESTING} THIS_XCORE_TILE=1)
+target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS} ${APP_EXT_COMPILER_FLAGS})
+target_link_libraries(${TARGET_NAME} PUBLIC ${APP_COMMON_LINK_LIBRARIES} ${APP_EXT_COMMON_LINK_LIBRARIES} sln_avona::app::ffd::xcore_ai_explorer)
+target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS} )
+unset(TARGET_NAME)
+
+set(TARGET_NAME tile0_application_ffd_usb_audio_test_bypass_ap)
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
+target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES} ${APP_EXT_SOURCES})
+target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES} ${APP_EXT_INCLUDES})
+target_compile_definitions(${TARGET_NAME} PUBLIC ${APP_COMPILE_DEFINITIONS} ${APP_EXT_COMPILE_DEFINITIONS} ${KEYWORD_USB_TESTING} ${BYPASS_AUDIOPIPELINE_DEFINITIONS} THIS_XCORE_TILE=0)
+target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS} ${APP_EXT_COMPILER_FLAGS})
+target_link_libraries(${TARGET_NAME} PUBLIC ${APP_COMMON_LINK_LIBRARIES} ${APP_EXT_COMMON_LINK_LIBRARIES} sln_avona::app::ffd::xk_voice_l71_ext)
+target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS})
+unset(TARGET_NAME)
+
+set(TARGET_NAME tile1_application_ffd_usb_audio_test_bypass_ap)
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
+target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES} ${APP_EXT_SOURCES})
+target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES} ${APP_EXT_INCLUDES})
+target_compile_definitions(${TARGET_NAME} PUBLIC ${APP_COMPILE_DEFINITIONS} ${APP_EXT_COMPILE_DEFINITIONS} ${KEYWORD_USB_TESTING} ${BYPASS_AUDIOPIPELINE_DEFINITIONS} THIS_XCORE_TILE=1)
+target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS} ${APP_EXT_COMPILER_FLAGS})
+target_link_libraries(${TARGET_NAME} PUBLIC ${APP_COMMON_LINK_LIBRARIES} ${APP_EXT_COMMON_LINK_LIBRARIES} sln_avona::app::ffd::xk_voice_l71_ext)
+target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS} )
+unset(TARGET_NAME)
+
+set(TARGET_NAME tile0_application_ffd_usb_audio_test_bypass_ap_dev)
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
+target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES} ${APP_EXT_SOURCES})
+target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES} ${APP_EXT_INCLUDES})
+target_compile_definitions(${TARGET_NAME} PUBLIC ${APP_COMPILE_DEFINITIONS} ${APP_EXT_COMPILE_DEFINITIONS} ${KEYWORD_USB_TESTING} ${BYPASS_AUDIOPIPELINE_DEFINITIONS} THIS_XCORE_TILE=0)
+target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS} ${APP_EXT_COMPILER_FLAGS})
+target_link_libraries(${TARGET_NAME} PUBLIC ${APP_COMMON_LINK_LIBRARIES} ${APP_EXT_COMMON_LINK_LIBRARIES} sln_avona::app::ffd::xcore_ai_explorer)
+target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS})
+unset(TARGET_NAME)
+
+set(TARGET_NAME tile1_application_ffd_usb_audio_test_bypass_ap_dev)
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
+target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES} ${APP_EXT_SOURCES})
+target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES} ${APP_EXT_INCLUDES})
+target_compile_definitions(${TARGET_NAME} PUBLIC ${APP_COMPILE_DEFINITIONS} ${APP_EXT_COMPILE_DEFINITIONS} ${KEYWORD_USB_TESTING} ${BYPASS_AUDIOPIPELINE_DEFINITIONS} THIS_XCORE_TILE=1)
 target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS} ${APP_EXT_COMPILER_FLAGS})
 target_link_libraries(${TARGET_NAME} PUBLIC ${APP_COMMON_LINK_LIBRARIES} ${APP_EXT_COMMON_LINK_LIBRARIES} sln_avona::app::ffd::xcore_ai_explorer)
 target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS} )
@@ -54,13 +103,20 @@ unset(TARGET_NAME)
 merge_binaries(application_ffd_usb_audio_test tile0_application_ffd_usb_audio_test tile1_application_ffd_usb_audio_test 1)
 merge_binaries(application_ffd_usb_audio_test_dev tile0_application_ffd_usb_audio_test_dev tile1_application_ffd_usb_audio_test_dev 1)
 
+merge_binaries(application_ffd_usb_audio_test_bypass_ap tile0_application_ffd_usb_audio_test_bypass_ap tile1_application_ffd_usb_audio_test_bypass_ap 1)
+merge_binaries(application_ffd_usb_audio_test_bypass_ap_dev tile0_application_ffd_usb_audio_test_bypass_ap_dev tile1_application_ffd_usb_audio_test_bypass_ap_dev 1)
+
 #**********************
 # Create run and debug targets
 #**********************
 create_run_target(application_ffd_usb_audio_test)
 create_debug_target(application_ffd_usb_audio_test)
-create_flash_app_target(application_ffd_usb_audio_test)
 
 create_run_target(application_ffd_usb_audio_test_dev)
 create_debug_target(application_ffd_usb_audio_test_dev)
-create_flash_app_target(application_ffd_usb_audio_test_dev)
+
+create_run_target(application_ffd_usb_audio_test_bypass_ap)
+create_debug_target(application_ffd_usb_audio_test_bypass_ap)
+
+create_run_target(application_ffd_usb_audio_test_bypass_ap_dev)
+create_debug_target(application_ffd_usb_audio_test_bypass_ap_dev)

--- a/applications/ffd/ffd.cmake
+++ b/applications/ffd/ffd.cmake
@@ -73,6 +73,7 @@ merge_binaries(application_ffd tile0_application_ffd tile1_application_ffd 1)
 create_run_target(application_ffd)
 create_debug_target(application_ffd)
 create_flash_app_target(application_ffd)
+
 #**********************
 # Include FFD Debug and Extension targets
 #**********************

--- a/applications/ffd/host/usb_host.py
+++ b/applications/ffd/host/usb_host.py
@@ -1,53 +1,68 @@
+#!/usr/bin/env python
+# Copyright (c) 2022 XMOS LIMITED. This Software is subject to the terms of the
+# XMOS Public License: Version 1
+
 import usb.core
 import usb.util
+import argparse
 
 from time import sleep
 
-OP_CODE_GET_LAST_INTENT_HEX = "01"
-KEYWORD_ENDPOINT = 0x82
+def run(outfile):
+    f = open(outfile, "w", encoding="utf-8")
 
-# find our device
-dev = usb.core.find(idVendor=0x20B1, idProduct=0x0020)
+    OP_CODE_GET_LAST_INTENT_HEX = "01"
+    KEYWORD_ENDPOINT = 0x82
 
-if dev is None:
-    raise ValueError('Avona device not found')
+    # find our device
+    dev = usb.core.find(idVendor=0x20B1, idProduct=0x0020)
 
-# print(dev)
+    if dev is None:
+        raise ValueError('Avona device not found')
 
-dev.reset()
-dev.set_configuration()
-dev.reset()
+    if dev.is_kernel_driver_active(1):
+        dev.detach_kernel_driver(1)
+    # print(dev)
 
-intent_to_text = {
-    100 : "Hello XMOS",
-    110 : "Hello Wanson",
-    200 : "Switch On the TV",
-    210 : "Switch Off the TV",
-    220 : "Channel Up",
-    230 : "Channel Down",
-    240 : "Volume Up",
-    250 : "Volume Down",
-    300 : "Switch On the Lights",
-    310 : "Switch Off the Lights",
-    320 : "Brightness Up",
-    330 : "Brightness Down",
-    400 : "Switch On the Fan",
-    410 : "Switch Off the Fan",
-    420 : "Speed Up the Fan",
-    430 : "Slow Down the Fan",
-    440 : "Set Higher Temperature",
-    450 : "Set Lower Temperature"
-}
+    intent_to_text = {
+        100 : "Hello XMOS",
+        110 : "Hello Wanson",
+        200 : "Switch On the TV",
+        210 : "Switch Off the TV",
+        220 : "Channel Up",
+        230 : "Channel Down",
+        240 : "Volume Up",
+        250 : "Volume Down",
+        300 : "Switch On the Lights",
+        310 : "Switch Off the Lights",
+        320 : "Brightness Up",
+        330 : "Brightness Down",
+        400 : "Switch On the Fan",
+        410 : "Switch Off the Fan",
+        420 : "Speed Up the Fan",
+        430 : "Slow Down the Fan",
+        440 : "Set Higher Temperature",
+        450 : "Set Lower Temperature"
+    }
 
-while True:
-    sleep(0.1)
-    try:
-        dev.write(0x02, bytes.fromhex(OP_CODE_GET_LAST_INTENT_HEX))
-        resp = dev.read(KEYWORD_ENDPOINT, 4)
-        if resp:
-            int_val = int.from_bytes(resp, "little")
+    while True:
+        sleep(0.1)
+        try:
+            dev.write(0x02, bytes.fromhex(OP_CODE_GET_LAST_INTENT_HEX))
+            resp = dev.read(KEYWORD_ENDPOINT, 4)
+            if resp:
+                int_val = int.from_bytes(resp, "little")
 
-            if int_val in intent_to_text.keys():
-                print(intent_to_text[int_val])
-    except:
-        continue
+                if int_val in intent_to_text.keys():
+                    print(intent_to_text[int_val])
+                    f.write(intent_to_text[int_val] + "\n")
+        except:
+            continue
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=("Requests USB transfers from FFD and writes keywords to a file."))
+    parser.add_argument("--outfile", help="Output filename", required=True)
+    args = parser.parse_args()
+
+    run(args.outfile)

--- a/applications/ffd/inference/wanson/wanson_inf_eng.c
+++ b/applications/ffd/inference/wanson/wanson_inf_eng.c
@@ -47,7 +47,7 @@ void wanson_engine_task(void *args)
 
 #if ON_TILE(0)
     // NOTE: The Wanson model uses the .SwMem_data attribute but no SwMem event handling code is required.
-    //       This may cause xflash to whine if the compiler optimizes out the __swmem_address symbol. 
+    //       This may cause xflash to whine if the compiler optimizes out the __swmem_address symbol.
     //       To work around this, we simply need to init the swmem.
     rtos_swmem_init(0);
 #endif
@@ -60,8 +60,8 @@ void wanson_engine_task(void *args)
     TimerHandle_t display_clear_timer = xTimerCreate(
         "disp_clr",
         pdMS_TO_TICKS(appconfINFERENCE_RESET_DELAY_MS),
-        pdFALSE, 
-        NULL, 
+        pdFALSE,
+        NULL,
         vDisplayClearCallback);
 
     int32_t buf[appconfINFERENCE_FRAMES_PER_INFERENCE] = {0};
@@ -106,6 +106,9 @@ void wanson_engine_task(void *args)
         ret = Wanson_ASR_Recog(buf_short, appconfINFERENCE_FRAMES_PER_INFERENCE, (const char **)&text_ptr, &id);
 
         if (ret) {
+#if appconfINFERENCE_RAW_OUTPUT
+            wanson_engine_proc_keyword_result((const char **)&text_ptr, id);
+#else
             if (inference_state == STATE_EXPECTING_WAKEWORD && IS_WAKEWORD(id)) {
                 xTimerReset(display_clear_timer, 0);
                 wanson_engine_proc_keyword_result((const char **)&text_ptr, id);
@@ -127,6 +130,7 @@ void wanson_engine_task(void *args)
                 wanson_engine_proc_keyword_result((const char **)&text_ptr, id);
                 // remain in STATE_PROCESSING_COMMAND state
             }
+#endif
         }
 
         /* Push back history */

--- a/applications/ffd/src/app_conf.h
+++ b/applications/ffd/src/app_conf.h
@@ -35,6 +35,10 @@
 #define appconfINFERENCE_ENABLED   1
 #endif
 
+#ifndef appconfINFERENCE_RAW_OUTPUT
+#define appconfINFERENCE_RAW_OUTPUT   0
+#endif
+
 #ifndef appconfINFERENCE_I2C_OUTPUT_ENABLED
 #define appconfINFERENCE_I2C_OUTPUT_ENABLED   0
 #endif
@@ -53,6 +57,18 @@
 
 #ifndef appconfI2S_ENABLED
 #define appconfI2S_ENABLED   0
+#endif
+
+#ifndef appconfAUDIO_PIPELINE_SKIP_IC_AND_VAD
+#define appconfAUDIO_PIPELINE_SKIP_IC_AND_VAD   0
+#endif
+
+#ifndef appconfAUDIO_PIPELINE_SKIP_NS
+#define appconfAUDIO_PIPELINE_SKIP_NS   0
+#endif
+
+#ifndef appconfAUDIO_PIPELINE_SKIP_AGC
+#define appconfAUDIO_PIPELINE_SKIP_AGC   0
 #endif
 
 #ifndef appconfI2S_AUDIO_SAMPLE_RATE

--- a/applications/ffd/src/audio_pipeline/audio_pipeline.c
+++ b/applications/ffd/src/audio_pipeline/audio_pipeline.c
@@ -87,6 +87,9 @@ static int audio_pipeline_output_i(frame_data_t *frame_data,
 
 static void stage_vad_and_ic(frame_data_t *frame_data)
 {
+#if appconfAUDIO_PIPELINE_SKIP_IC_AND_VAD
+    (void) frame_data;
+#else
     int32_t ic_output[appconfAUDIO_PIPELINE_FRAME_ADVANCE];
 
     ic_filter(&ic_stage_state.state,
@@ -97,10 +100,14 @@ static void stage_vad_and_ic(frame_data_t *frame_data)
     ic_adapt(&ic_stage_state.state, vad, ic_output);
     frame_data->vad = vad;
     memcpy(frame_data->samples, ic_output, appconfAUDIO_PIPELINE_FRAME_ADVANCE * sizeof(int32_t));
+#endif
 }
 
 static void stage_ns(frame_data_t *frame_data)
 {
+#if appconfAUDIO_PIPELINE_SKIP_NS
+    (void) frame_data;
+#else
     int32_t ns_output[appconfAUDIO_PIPELINE_FRAME_ADVANCE];
     configASSERT(NS_FRAME_ADVANCE == appconfAUDIO_PIPELINE_FRAME_ADVANCE);
     ns_process_frame(
@@ -108,10 +115,14 @@ static void stage_ns(frame_data_t *frame_data)
                 ns_output,
                 frame_data->samples[0]);
     memcpy(frame_data->samples, ns_output, appconfAUDIO_PIPELINE_FRAME_ADVANCE * sizeof(int32_t));
+#endif
 }
 
 static void stage_agc(frame_data_t *frame_data)
 {
+#if appconfAUDIO_PIPELINE_SKIP_AGC
+    (void) frame_data;
+#else
     int32_t agc_output[appconfAUDIO_PIPELINE_FRAME_ADVANCE];
     configASSERT(AGC_FRAME_ADVANCE == appconfAUDIO_PIPELINE_FRAME_ADVANCE);
 
@@ -123,6 +134,7 @@ static void stage_agc(frame_data_t *frame_data)
             frame_data->samples[0],
             &agc_stage_state.md);
     memcpy(frame_data->samples, agc_output, appconfAUDIO_PIPELINE_FRAME_ADVANCE * sizeof(int32_t));
+#endif
 }
 
 static void initialize_pipeline_stages(void) {


### PR DESCRIPTION
Extends the usb debug config to output wakeword code over usb.  Extends
host script to write keywords to file.

Fixes potential concurrency bug around last_intent in usb output.