### PR TITLE
update cmake minimum required version to 3.21 in asrc sim test

### DIFF
--- a/test/asrc_sim/CMakeLists.txt
+++ b/test/asrc_sim/CMakeLists.txt
@@ -8,7 +8,7 @@ add_compile_definitions(NUMCPP_NO_USE_BOOST=1)
 include(FetchContent)
 FetchContent_Declare(SystemC
         GIT_REPOSITORY https://github.com/accellera-official/systemc
-        GIT_TAG 2.3.4)
+        GIT_TAG 3.0.1)
 FetchContent_MakeAvailable(SystemC)
 
 FetchContent_Declare(NumCpp

--- a/test/asrc_sim/CMakeLists.txt
+++ b/test/asrc_sim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.21)
 project(usb_in_i2s_out)
 
 set (CMAKE_CXX_STANDARD 17 CACHE STRING CXX_Standard)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/xmos/audio_test_tools@develop#egg=audio_test_tools&subdirectory=python
+-e git+https://github.com/xmos/audio_test_tools@feature/pyproject#egg=audio_test_tools&subdirectory=python
 matplotlib==3.3.1
 numpy>=1.19.5,<2
 pylint==2.5.3


### PR DESCRIPTION
matching cmake file in root of repo. 
Required for ubu 24 builders as they otherwise complain that support for 3.0 has bene dropped