### PR TITLE
Fix software PLL not locked in FFVA-INT (AEC not converge in FFVA-INT)

### DIFF
--- a/examples/ffva/bsp_config/XK_VOICE_L71/platform/platform_start.c
+++ b/examples/ffva/bsp_config/XK_VOICE_L71/platform/platform_start.c
@@ -20,6 +20,7 @@
 #include "device_control_i2c.h"
 
 extern void i2s_rate_conversion_enable(void);
+extern void i2s_restart_callback_enable(void);
 
 static void gpio_start(void)
 {
@@ -113,6 +114,9 @@ static void i2s_start(void)
 #if appconfI2S_ENABLED
 #if appconfI2S_MODE == appconfI2S_MODE_MASTER
     rtos_i2s_rpc_config(i2s_ctx, appconfI2S_RPC_PORT, appconfI2S_RPC_PRIORITY);
+#endif
+#if ON_TILE(I2S_TILE_NO) && appconfRECOVER_MCLK_I2S_APP_PLL
+    i2s_restart_callback_enable();
 #endif
 #if ON_TILE(I2S_TILE_NO)
     if (appconfI2S_AUDIO_SAMPLE_RATE == 3*appconfAUDIO_PIPELINE_SAMPLE_RATE) {

--- a/examples/ffva/src/main.c
+++ b/examples/ffva/src/main.c
@@ -73,7 +73,7 @@ void i2s_slave_intertile(void *args) {
 
 #if ON_TILE(I2S_TILE_NO) && appconfRECOVER_MCLK_I2S_APP_PLL
 RTOS_I2S_APP_RESTART_CALLBACK_ATTR
-size_t i2s_restart_cb(rtos_i2s_t *ctx, void *app_data)
+i2s_restart_t i2s_restart_cb(rtos_i2s_t *ctx, void *app_data)
 {
     sw_pll_ctx_t* i2s_callback_args = (sw_pll_ctx_t*) app_data;
     port_clear_buffer(i2s_callback_args->p_bclk_count);
@@ -82,6 +82,8 @@ size_t i2s_restart_cb(rtos_i2s_t *ctx, void *app_data)
     uint16_t bclk_pt = port_get_trigger_time(i2s_callback_args->p_bclk_count); // Now grab bclk_count (which won't have changed)
     
     sw_pll_lut_do_control(i2s_callback_args->sw_pll, mclk_pt, bclk_pt);
+
+    return I2S_NO_RESTART;
 }
 
 void i2s_restart_callback_enable() {

--- a/examples/ffva/src/main.c
+++ b/examples/ffva/src/main.c
@@ -66,19 +66,26 @@ void i2s_slave_intertile(void *args) {
                     (int32_t*) tmp,
                     appconfAUDIO_PIPELINE_FRAME_ADVANCE,
                     portMAX_DELAY);
+    }
+}
+#endif
 
 
 #if ON_TILE(I2S_TILE_NO) && appconfRECOVER_MCLK_I2S_APP_PLL
-    sw_pll_ctx_t* i2s_callback_args = (sw_pll_ctx_t*) args;
+RTOS_I2S_APP_RESTART_CALLBACK_ATTR
+size_t i2s_restart_cb(rtos_i2s_t *ctx, void *app_data)
+{
+    sw_pll_ctx_t* i2s_callback_args = (sw_pll_ctx_t*) app_data;
     port_clear_buffer(i2s_callback_args->p_bclk_count);
     port_in(i2s_callback_args->p_bclk_count);                                  // Block until BCLK transition to synchronise. Will consume up to 1/64 of a LRCLK cycle
     uint16_t mclk_pt = port_get_trigger_time(i2s_callback_args->p_mclk_count); // Immediately sample mclk_count
     uint16_t bclk_pt = port_get_trigger_time(i2s_callback_args->p_bclk_count); // Now grab bclk_count (which won't have changed)
-
+    
     sw_pll_lut_do_control(i2s_callback_args->sw_pll, mclk_pt, bclk_pt);
-#endif
+}
 
-    }
+void i2s_restart_callback_enable() {
+    rtos_i2s_restart_cb_set(i2s_ctx, i2s_restart_cb, sw_pll_ctx);
 }
 #endif
 
@@ -213,6 +220,7 @@ int audio_pipeline_output(void *output_app_data,
 #endif
 
 #elif appconfI2S_MODE == appconfI2S_MODE_SLAVE
+    xassert(frame_count == appconfAUDIO_PIPELINE_FRAME_ADVANCE);
     /* I2S expects sample channel format */
     int32_t tmp[appconfAUDIO_PIPELINE_FRAME_ADVANCE][appconfAUDIO_PIPELINE_CHANNELS];
     int32_t *tmpptr = (int32_t *)output_audio_frames;

--- a/examples/ffva/src/main.c
+++ b/examples/ffva/src/main.c
@@ -80,7 +80,7 @@ i2s_restart_t i2s_restart_cb(rtos_i2s_t *ctx, void *app_data)
     port_in(i2s_callback_args->p_bclk_count);                                  // Block until BCLK transition to synchronise. Will consume up to 1/64 of a LRCLK cycle
     uint16_t mclk_pt = port_get_trigger_time(i2s_callback_args->p_mclk_count); // Immediately sample mclk_count
     uint16_t bclk_pt = port_get_trigger_time(i2s_callback_args->p_bclk_count); // Now grab bclk_count (which won't have changed)
-    
+
     sw_pll_lut_do_control(i2s_callback_args->sw_pll, mclk_pt, bclk_pt);
 
     return I2S_NO_RESTART;


### PR DESCRIPTION
In FFVA-INT example, software PLL is used to phase lock MCLK with BCLK to eliminate the need of external MCLK.
However, sw_pll_lut_do_control in the original code is called every 240 I2S frame instead of every I2S frame.
This causes the software PLL failed to lock, thus the AEC not converge in FFVA-INT.

This PR put the sw_pll_lut_do_control call in I2S restart callback; this make sure it is called in every I2S frame.
This PR rely on the [PR#256](https://github.com/xmos/fwk_rtos/pull/256) on fwk_rtos, [PR#256](https://github.com/xmos/fwk_rtos/pull/256) need to be merged before this PR can compile.